### PR TITLE
fix: Standardize action naming: rename `remove` to `removed`

### DIFF
--- a/handlers/adapter.go
+++ b/handlers/adapter.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	source       = "eventhub"
-	actionAdded  = "added"
-	actionSet    = "set"
-	actionRemove = "remove"
+	source        = "eventhub"
+	actionAdded   = "added"
+	actionSet     = "set"
+	actionRemoved = "removed"
 )
 
 // HandlerAdapter is a wrapper for handling variable operations.
@@ -98,7 +98,7 @@ func (r *HandlerAdapter) RemoveElementFromSet(ctx context.Context, variableKey s
 			Hub:            hubName,
 			VarName:        variableKey,
 			VarType:        variables.DataTypeSet,
-			Action:         actionRemove,
+			Action:         actionRemoved,
 			Data:           value,
 			CorrelationID:  correlationId,
 			Source:         source,
@@ -150,7 +150,7 @@ func (r *HandlerAdapter) RemoveMapEntry(ctx context.Context, variableKey string,
 			Hub:            hubName,
 			VarName:        variableKey,
 			VarType:        variables.DataTypeMap,
-			Action:         actionRemove,
+			Action:         actionRemoved,
 			Data:           field,
 			CorrelationID:  correlationId,
 			Source:         source,
@@ -199,7 +199,7 @@ func (r *HandlerAdapter) DeleteStringValue(ctx context.Context, variableKey stri
 			Hub:            hubName,
 			VarName:        variableKey,
 			VarType:        variables.DataTypeString,
-			Action:         actionRemove,
+			Action:         actionRemoved,
 			Data:           "",
 			CorrelationID:  correlationId,
 			Source:         source,

--- a/handlers/adapter_test.go
+++ b/handlers/adapter_test.go
@@ -142,16 +142,16 @@ func TestDeleteStringValue(t *testing.T) {
 	)
 	pub.EXPECT().Publish(ctx, gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, event eventing.MdaiEvent, subject eventing.MdaiEventSubject) error {
-			assert.Equal(t, "var.remove", event.Name)
+			assert.Equal(t, "var.removed", event.Name)
 			assert.Equal(t, hubName, event.HubName)
 			assert.Equal(t, correlationId, event.CorrelationID)
-			assert.Equal(t, fmt.Sprintf("trigger.vars.remove.%s.%s", hubName, variableKey), subject.String())
+			assert.Equal(t, fmt.Sprintf("trigger.vars.removed.%s.%s", hubName, variableKey), subject.String())
 
 			var payload eventing.VariablesActionPayload
 			require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
 			assert.Equal(t, variableKey, payload.VariableRef)
 			assert.Equal(t, "string", payload.DataType)
-			assert.Equal(t, "remove", payload.Operation)
+			assert.Equal(t, "removed", payload.Operation)
 			assert.Empty(t, payload.Data)
 			return nil
 		})
@@ -338,12 +338,12 @@ func TestRemoveMapEntry_BehaviorAndPayload(t *testing.T) {
 
 	pub.EXPECT().Publish(ctx, gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, ev eventing.MdaiEvent, subj eventing.MdaiEventSubject) error {
-			assert.Equal(t, "var.remove", ev.Name)
-			assert.Equal(t, fmt.Sprintf("trigger.vars.remove.%s.%s", hub, key), subj.String())
+			assert.Equal(t, "var.removed", ev.Name)
+			assert.Equal(t, fmt.Sprintf("trigger.vars.removed.%s.%s", hub, key), subj.String())
 			var pl eventing.VariablesActionPayload
 			require.NoError(t, json.Unmarshal([]byte(ev.Payload), &pl))
 			assert.Equal(t, "map", pl.DataType)
-			assert.Equal(t, "remove", pl.Operation)
+			assert.Equal(t, "removed", pl.Operation)
 			// current implementation passes 'field'
 			assert.Equal(t, field, pl.Data)
 			return nil


### PR DESCRIPTION
Fix variable removal trigger events to use the CRD rule vocabulary removed instead of remove. This aligns emitted variable trigger events with MdaiHub updateType: removed rules so delete/remove automations can match and execute.
<!--
For Work In Progress pull requests, please use the Draft PR feature.

For a timely review/response, please avoid force-pushing additional
commits if your PR already received reviews or comments.

Before submitting a pull request, please ensure you've done the following:
- Create small PRs. In most cases this will be possible.
- Provide tests for your changes.
- Add/update relevant documentation(s).
- Fill out the pull request template.
- Ensure your PR title follow the guideline described in: 
  https://github.com/MyDecisive/changelogs?tab=readme-ov-file#pull-request-title
-->

## Description
<!--
Please describe the changes you made in this pull request.

If applicable, please feel free to include screenshots to make it
easier for reviewers understand your pull request. 

If there are any relevant documentations that help explain your pull
request, please feel free to include them as well.
-->

- ENG-1377

## What type of PR is this? (only check one)
<!--
If you need to check more than one (except if the other type is `doc`, 
always do add more doc) to properly capture the PR type, please 
consider splitting up your PR.

If you selected Other, please ensure the type you provided
is one of the valid types outlined in
https://github.com/MyDecisive/changelogs?tab=readme-ov-file#type
-->

- [ ] Feature (`feat`)
- [x] Bug Fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Documentation Update (`doc`)
- [ ] Other, please specify: 

### Does this PR introduce any breaking changes?
- [x] No
- [ ] Yes, and this is why: 
- [ ] I need help determining if there are any breaking changes

### Does the PR title type prefix match the selected type?
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help select the right one

## Added/updated tests?
_Please keep the code coverage percentage at 80% and above._
- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

<!--
Uncomment this section if needed:
## Updated [`mdai-labs`](https://github.com/MyDecisive/mdai-labs) to reflect changes done in this PR?
- [ ] Yes
- [ ] N/A
- [ ] I need help, please elaborate: 
-->
